### PR TITLE
Proposal for mask to allow movement of just one axis.

### DIFF
--- a/proto/axesservice/rotational/v1/rotational_axesservice.proto
+++ b/proto/axesservice/rotational/v1/rotational_axesservice.proto
@@ -43,6 +43,10 @@ service HardwareController {
 // Position of a rotational axes stage
 message RotationalPosition {
   repeated double rotational_coordinates_in_rad = 1;
+  
+  // mask to indicate which values are valid / should be used.
+  // especially usefull to just move one axis / dimension
+  repeated bool mask = 2;
 }
 
 // Positional limits of a rotational axes stage


### PR DESCRIPTION
Simple idea:

Add a mask field for coordinate arrays. Example shown for the simple rotational movement.

This allows to indicate which axes / dimensions should be moved. Otherwise, to move just one axis, I need to get the current position, change one value, send all coordinates back, which effectively doubles the number of requests.

I propose to add this as a general feature for repeated coordinates. If everyone agrees, I volunteer to go over all proto files and insert the field to all coordinate arrays.